### PR TITLE
Modified `fetch_paper()` and added `ArxivPaper` dataclass for optimality

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The `ArxivSummarizer` is a Python class designed for summarizing ArXiv documents
     - [With Custom SummarizationModel](#with-custom-summarizationmodel)
     - [With Pre-trained Model by Name](#with-pre-trained-model-by-name)
     - [With Default Models](#with-default-models)
+    - [Fetching a list of papers](#fetching-a-list-of-papers)
   - [Examples](#examples)
   - [Contributing](#contributing)
   - [License](#license)
@@ -84,6 +85,94 @@ summarizer = ArxivSummarizer()
 # Generate a summary
 summary = summarizer(arxiv_id="1234.5678")
 print(summary)
+```
+
+### Fetching a list of papers
+
+First we can search a list of papers directly using the `fetch_paper()` definition.
+```python
+from rich.progress import Progress
+from rich.console import Console
+from rich.table import Table
+
+from typing import List
+from arxiv_summarizer.fetch_paper import fetch_paper, ArxivPaper
+
+# Get the list of papers
+papers = fetch_paper("Yoshua Bengio", max_docs=15)
+results : List[ArxivPaper] = [paper for paper in papers]
+
+print(f"{len(results)} Papers Found !!!")
+```
+
+This will load the papers, their metadata and their summaries. Now we can download the content of the paper and show the progress using a progressbar from `rich`.
+```python
+# Download the papers
+with Progress() as progress:
+    task = progress.add_task("[cyan] Downloading content...", total = len(results))
+
+    for index, paper in enumerate(results):
+        progress.update(task, advance=1, description=f"Downloading content for paper {paper.arxiv_id}")
+        _ = results[index].content # This will download the content automatically.
+```
+
+Once all the content has been downloaded, we can display the content in a tabular structure using a `rich` Table.
+```python
+# Print the data
+console = Console()
+
+table = Table(show_header=True, header_style="bold magenta")
+table.add_column("ID", style="dim")
+table.add_column("Title", style="dim")
+table.add_column("Authors", style="dim")
+table.add_column("Content Size", style="dim")
+
+for entry in results:
+    entry:ArxivPaper
+    table.add_row(entry.arxiv_id, entry.name, ", ".join(entry.authors), str(len(entry.content)))
+
+console.print(table)
+```
+
+```
+15 Papers Found !!!
+Downloading content for paper 1203.4416v1 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
+┏━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
+┃ ID           ┃ Title                                      ┃ Authors                                    ┃ Content Size ┃
+┡━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━┩
+│ 1206.5533v2  │ Practical recommendations for              │ Yoshua Bengio                              │ 134815       │
+│              │ gradient-based training of deep            │                                            │              │
+│              │ architectures                              │                                            │              │
+│ 1207.4404v1  │ Better Mixing via Deep Representations     │ Yoshua Bengio, Grégoire Mesnil, Yann       │ 31767        │
+│              │                                            │ Dauphin, Salah Rifai                       │              │
+│ 1305.0445v2  │ Deep Learning of Representations: Looking  │ Yoshua Bengio                              │ 121365       │
+│              │ Forward                                    │                                            │              │
+│ 1212.2686v1  │ Joint Training of Deep Boltzmann Machines  │ Ian Goodfellow, Aaron Courville, Yoshua    │ 13806        │
+│              │                                            │ Bengio                                     │              │
+│ 1703.07718v1 │ Independently Controllable Features        │ Emmanuel Bengio, Valentin Thomas, Joelle   │ 19385        │
+│              │                                            │ Pineau, Doina Precup, Yoshua Bengio        │              │
+│ 1211.5063v2  │ On the difficulty of training Recurrent    │ Razvan Pascanu, Tomas Mikolov, Yoshua      │ 50908        │
+│              │ Neural Networks                            │ Bengio                                     │              │
+│ 1206.5538v3  │ Representation Learning: A Review and New  │ Yoshua Bengio, Aaron Courville, Pascal     │ 194906       │
+│              │ Perspectives                               │ Vincent                                    │              │
+│ 1207.0057v1  │ Implicit Density Estimation by Local       │ Yoshua Bengio, Guillaume Alain, Salah      │ 35635        │
+│              │ Moment Matching to Sample from             │ Rifai                                      │              │
+│              │ Auto-Encoders                              │                                            │              │
+│ 1305.6663v4  │ Generalized Denoising Auto-Encoders as     │ Yoshua Bengio, Li Yao, Guillaume Alain,    │ 33769        │
+│              │ Generative Models                          │ Pascal Vincent                             │              │
+│ 1311.6184v4  │ Bounding the Test Log-Likelihood of        │ Yoshua Bengio, Li Yao, Kyunghyun Cho       │ 23711        │
+│              │ Generative Models                          │                                            │              │
+│ 1510.02777v2 │ Early Inference in Energy-Based Models     │ Yoshua Bengio, Asja Fischer                │ 26477        │
+│              │ Approximates Back-Propagation              │                                            │              │
+│ 1509.05936v2 │ STDP as presynaptic activity times rate of │ Yoshua Bengio, Thomas Mesnard, Asja        │ 22030        │
+│              │ change of postsynaptic activity            │ Fischer, Saizheng Zhang, Yuhuai Wu         │              │
+│ 1103.2832v1  │ Autotagging music with conditional         │ Michael Mandel, Razvan Pascanu, Hugo       │ 47698        │
+│              │ restricted Boltzmann machines              │ Larochelle, Yoshua Bengio                  │              │
+│ 2007.15139v2 │ Deriving Differential Target Propagation   │ Yoshua Bengio                              │ 63661        │
+│              │ from Iterating Approximate Inverses        │                                            │              │
+│ 1203.4416v1  │ On Training Deep Boltzmann Machines        │ Guillaume Desjardins, Aaron Courville,     │ 20531        │
+│              │                                            │ Yoshua Bengio                              │              │
+└──────────────┴────────────────────────────────────────────┴────────────────────────────────────────────┴──────────────┘
 ```
 
 ## Examples

--- a/src/arxiv_summarizer/arxiv_wrapper.py
+++ b/src/arxiv_summarizer/arxiv_wrapper.py
@@ -114,19 +114,19 @@ class ArxivAPIWrapper(BaseModel):
                 ).results()
         except self.arxiv_exceptions as ex:
             return [Document(page_content=f"Arxiv exception: {ex}")]
-        docs = [
-            Document(
-                page_content=result.summary,
-                metadata={
-                    "entry_id": result.entry_id,
-                    "Published": result.updated.date(),
-                    "Title": result.title,
-                    "Authors": ", ".join(a.name for a in result.authors),
-                },
-            )
-            for result in results
-        ]
-        return docs
+        # docs = [
+        #     Document(
+        #         page_content=result.summary,
+        #         metadata={
+        #             "entry_id": result.entry_id,
+        #             "Published": result.updated.date(),
+        #             "Title": result.title,
+        #             "Authors": ", ".join(a.name for a in result.authors),
+        #         },
+        #     )
+        #     for result in results
+        # ]
+        return results
 
     def run(self, query: str) -> str:
         """

--- a/src/arxiv_summarizer/arxiv_wrapper.py
+++ b/src/arxiv_summarizer/arxiv_wrapper.py
@@ -113,19 +113,8 @@ class ArxivAPIWrapper(BaseModel):
                     query[: self.ARXIV_MAX_QUERY_LENGTH], max_results=self.top_k_results
                 ).results()
         except self.arxiv_exceptions as ex:
-            return [Document(page_content=f"Arxiv exception: {ex}")]
-        # docs = [
-        #     Document(
-        #         page_content=result.summary,
-        #         metadata={
-        #             "entry_id": result.entry_id,
-        #             "Published": result.updated.date(),
-        #             "Title": result.title,
-        #             "Authors": ", ".join(a.name for a in result.authors),
-        #         },
-        #     )
-        #     for result in results
-        # ]
+            raise Exception(f"Arxiv exception: {ex}")
+
         return results
 
     def run(self, query: str) -> str:

--- a/src/arxiv_summarizer/fetch_paper.py
+++ b/src/arxiv_summarizer/fetch_paper.py
@@ -1,31 +1,130 @@
-from langchain.document_loaders import ArxivLoader 
-
-from arxiv_summarizer.arxiv_wrapper import ArxivAPIWrapper
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import List, Tuple, Iterator
+from urllib.request import urlretrieve
+from tempfile import NamedTemporaryFile
 import warnings
 
+from arxiv_summarizer.arxiv_wrapper import ArxivAPIWrapper
+from langchain.document_loaders import ArxivLoader 
+from arxiv.arxiv import Result
 
-def fetch_paper(query, max_docs=1, load_all_metadata=True):
-    query=query.lower()
-    if (max_docs>50):
+@dataclass(slots=True)
+class ArxivPaper:
+    arxiv_id: str
+    name: str
+    authors: List[str]
+    summary: str
+    published: datetime
+    primary_category: str
+    categories: List[str]
+    pdf_url: str
+    links: List[Tuple[str, str, str, str]]
+    journal_ref: str
+    doi: str
+
+    # content: str
+    _content: int = field(repr=False, init=False, default = None)
+
+
+    @property
+    def content(self, ) -> str:
+        if self._content:
+            return self._content
+
+        try:
+            import fitz
+        except ImportError:
+            raise ImportError(
+                "PyMuPDF package not found, please install it with "
+                "`pip install pymupdf`"
+            )
+
+        with NamedTemporaryFile(mode = "r", delete = True, prefix="arxiv_", suffix=".pdf") as arxiv_pdf:
+            try:
+                doc_file_name, msg = urlretrieve(self.pdf_url, arxiv_pdf.name)
+                with fitz.open(doc_file_name) as doc_file:
+                    self._content: str = "".join(page.get_text() for page in doc_file)
+            except:
+                warnings.warn(f"Cannot fetch arxiv:{self.arxiv_id}. Possibly withdrawn.")
+                self._content = None
+                return None
+
+        return self._content
+    
+    @staticmethod
+    def from_result(result: Result):
+        paper = ArxivPaper(
+            arxiv_id = result.entry_id.split("/")[-1],
+            name = result.title,
+            authors = [
+                author.name for author in result.authors
+            ],
+            summary = result.summary,
+            published = result.published,
+            primary_category = result.primary_category,
+            categories = result.categories,
+            pdf_url = result.pdf_url,
+            links = [
+                (link.title, link.href, link.rel, link.content_type) for link in result.links
+            ],
+            journal_ref = result.journal_ref,
+            doi = result.doi
+        )
+        return paper
+
+def fetch_paper(query, max_docs = 1) -> Iterator[ArxivPaper]:
+    """Fetches ArXiv papers based on the given query.
+
+    Args:
+        query (str): The search query for ArXiv papers.
+        max_docs (int, optional): The maximum number of documents to fetch. Defaults to 1.
+
+    Returns:
+        List[ArxivPaper]: A list of ArXivPaper objects representing the fetched papers.
+
+    Yields:
+        Iterator[ArxivPaper]: A list of ArXivPaper objects representing the fetched papers.
+
+    Note:
+        The function uses the ArxivAPIWrapper to fetch paper summaries and metadata,
+        and then converts the results into ArxivPaper objects.
+
+    Raises:
+        ImportError: If the PyMuPDF package (required for extracting content from PDFs)
+        is not installed.
+
+    Warnings:
+        UserWarning: If the specified `max_docs` exceeds 50, it defaults to 50 documents.
+        UserWarning: If a paper cannot be fetched (possibly withdrawn), a warning is issued.
+
+    Example:
+        ```python
+        papers = fetch_paper("machine learning", max_docs=5)
+        for paper in papers:
+            print(paper.name, paper.authors, paper.published)
+        ```
+
+    """    
+    query = query.lower()
+
+    # TODO: This check won't be necessary anymore, as the "content" 
+    # is now being fetched, only when needed.
+    if (max_docs > 50):
         warnings.warn("Max docs exceeded 50, defaulting to 50 documents only")
+
     max_docs = min(50, max_docs)
 
-    client = ArxivAPIWrapper(doc_content_chars_max = None, top_k_results=max_docs, load_all_available_meta = load_all_metadata)
+    client = ArxivAPIWrapper(
+        doc_content_chars_max = None, 
+        top_k_results = max_docs, 
+        load_all_available_meta = True
+    )
 
-    #docs = ArxivLoader(query=query, load_max_docs=max_docs, load_all_available_meta = load_all_metadata).get_summaries_as_docs()
-    summaries = client.get_summaries_as_docs(query=query)
+    results = client.get_summaries_as_docs(query = query)
 
-    for doc in summaries:
-        yield (doc.metadata['Title'], doc.metadata['entry_id'].split("/")[-1])
-
-def fetch_content(query):
-    query = query.lower()
-    docs = ArxivLoader(query=query, load_max_docs=1, load_all_available_meta = True).load()
-
-    return docs[0].metadata, docs[0].page_content
-
-print(list(fetch_paper(query="transformer", max_docs=20)))
-
+    for res in results:
+        yield ArxivPaper.from_result(res)
 
 
 

--- a/src/arxiv_summarizer/fetch_paper.py
+++ b/src/arxiv_summarizer/fetch_paper.py
@@ -99,12 +99,14 @@ def fetch_paper(query, max_docs = 1) -> Iterator[ArxivPaper]:
         UserWarning: If a paper cannot be fetched (possibly withdrawn), a warning is issued.
 
     Example:
-        ```python
-        papers = fetch_paper("machine learning", max_docs=5)
-        for paper in papers:
-            print(paper.name, paper.authors, paper.published)
-        ```
+        .. code-block:: python
 
+            from arxiv_summarizer.fetch_paper import fetch_paper
+
+            papers = fetch_paper("machine learning", max_docs=5)
+            for paper in papers:
+                print(paper.name, paper.authors, paper.published)
+        
     """    
     query = query.lower()
 
@@ -118,6 +120,7 @@ def fetch_paper(query, max_docs = 1) -> Iterator[ArxivPaper]:
     client = ArxivAPIWrapper(
         doc_content_chars_max = None, 
         top_k_results = max_docs, 
+        load_max_docs = max_docs,
         load_all_available_meta = True
     )
 


### PR DESCRIPTION
Modified `fetch_paper()` function definition to act as a generator of `ArxivPaper` class which will contain the basic information like the name, arxiv id, author names, publishing date, urls etc and will parse the content, only when needed.

The below code shows an example of first load the papers and then, later downloading the "content" of the papers.

```python
from rich.progress import Progress
from rich.console import Console
from rich.table import Table

from typing import List
from arxiv_summarizer.fetch_paper import fetch_paper, ArxivPaper

# Get the list of papers
papers = fetch_paper("Yoshua Bengio", max_docs=15)
results : List[ArxivPaper] = [paper for paper in papers]

print(f"{len(results)} Papers Found !!!")

# Download the papers
with Progress() as progress:
    task = progress.add_task("[cyan] Downloading content...", total = len(results))

    for index, paper in enumerate(results):
        progress.update(task, advance=1, description=f"Downloading content for paper {paper.arxiv_id}")
        _ = results[index].content # This will download the content automatically.

# Print the data
console = Console()

table = Table(show_header=True, header_style="bold magenta")
table.add_column("ID", style="dim")
table.add_column("Title", style="dim")
table.add_column("Authors", style="dim")
table.add_column("Content Size", style="dim")

for entry in results:
    entry:ArxivPaper
    table.add_row(entry.arxiv_id, entry.name, ", ".join(entry.authors), str(len(entry.content)))

console.print(table)
```