### PR TITLE
fix: unable to retrieve paper in ArxivPaper.content

### DIFF
--- a/src/arxiv_summarizer/arxiv_wrapper.py
+++ b/src/arxiv_summarizer/arxiv_wrapper.py
@@ -103,6 +103,7 @@ class ArxivAPIWrapper(BaseModel):
 
         Args:
             query: a plaintext search query
+            offset: the offset of the search results
         """  # noqa: E501
         try:
             if self.is_arxiv_identifier(query):


### PR DESCRIPTION
- Fixes the `permission denied` error I faced in Windows. Should work universally